### PR TITLE
fixed aspect ratio of images on landing page and list images (object …

### DIFF
--- a/css/listview.css
+++ b/css/listview.css
@@ -96,7 +96,7 @@
        height:100%;
        max-height: 130px;
        max-width: 120px;
-
+       object-fit: cover;
     }
 
     .title-and-distancefrom {
@@ -357,6 +357,7 @@
         width: 100%;
         height: 100%;
         overflow: hidden;
+        object-fit: cover;
 
     }
     

--- a/css/listview.css
+++ b/css/listview.css
@@ -60,6 +60,7 @@
 
     .route-container:hover {
         box-shadow: 0 6px 9px rgba(0,0,0,0.16), 0 6px 9px rgba(0,0,0,0.23);
+        cursor: pointer;
     }
 
     .image-section {


### PR DESCRIPTION
…fit: cover)

@rfpoulos can you take a peak? Should fix all the issues with images getting stretched.